### PR TITLE
feat: allow error handling in replayer

### DIFF
--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -193,6 +193,7 @@ export type playerConfig = {
     warn: (...args: Parameters<typeof console.warn>) => void;
   };
   plugins?: ReplayPlugin[];
+  onError?: (e: Error) => void;
 };
 
 export type missingNode = {

--- a/packages/rrweb/test/replay/error-handler.test.ts
+++ b/packages/rrweb/test/replay/error-handler.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { polyfillWebGLGlobals } from '../utils';
+polyfillWebGLGlobals();
+
+import { EventType, eventWithTime } from '@rrweb/types';
+import { Replayer } from '../../src/replay';
+import type { playerConfig } from '../../typings/types';
+
+const event = (): eventWithTime => {
+  return {
+    timestamp: 1,
+    type: EventType.DomContentLoaded,
+    data: {},
+  };
+};
+
+describe('replayer error handler', () => {
+  function makeThrowingReplayer(config: Partial<playerConfig>) {
+    const errorThrowingStyleMirrorMock = {
+      getStyle: () => {
+        throw new Error('mock error');
+      },
+    };
+
+    const replayer = new Replayer(
+      // Get around the error "Replayer need at least 2 events."
+      [event(), event()],
+    );
+    (replayer as any).styleMirror = errorThrowingStyleMirrorMock;
+
+    return replayer;
+  }
+
+  it('the default is to throw an error', () => {
+    const replayer = makeThrowingReplayer({});
+    expect(() =>
+      replayer['applyIncremental'](
+        {
+          data: { source: 8, styleId: 'id-presence-causes-mock-to-be-called' },
+        } as unknown as any,
+        false,
+      ),
+    ).toThrow('mock error');
+  });
+  it('can receive an error handler', () => {
+    const errorHandler = jest.fn();
+    const replayer = makeThrowingReplayer({
+      onError: errorHandler,
+    });
+    expect(() =>
+      replayer['applyIncremental'](
+        {
+          data: { source: 8, styleId: 'id-presence-causes-mock-to-be-called' },
+        } as unknown as any,
+        false,
+      ),
+    ).not.toThrow('mock error');
+    expect(errorHandler).toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,15 +3543,15 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver@^7.5.0":
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
-  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
-
 "@types/semver@^7.3.12":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
   integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
+
+"@types/semver@^7.5.0":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -5564,14 +5564,9 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-cssom@^0.4.4, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
+cssom@^0.4.4, cssom@^0.5.0, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
   version "0.6.0"
   resolved "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
-
-cssom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
-  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 cssom@~0.3.6:
   version "0.3.8"


### PR DESCRIPTION
opening a pr just against our internal one for now

this is the PR version of the error handling we've patched into production

is it yucky? that the tests access private members - maybe but I don't want to change too much just yet

this PR adds

* optional onError config to `playerConfig` so existing codebases don't have to suddenly provide one
* defaults that to throwing - the existing behaviour - when constructing a player
* wraps incremental mutation application with an error handler that calls that handler instead of throwing if it is present

